### PR TITLE
Fix error and warning on the server.

### DIFF
--- a/R/juicedownApp-package.R
+++ b/R/juicedownApp-package.R
@@ -11,3 +11,6 @@
 #' @importFrom stringr str_split_1
 ## usethis namespace: end
 NULL
+
+
+.packageName <- "juicedownApp"


### PR DESCRIPTION
- Variable name .packageName was not defined.
- The shiny server warns due to the autoload mechanism.